### PR TITLE
GPU Build Fixes for Tensorflow (upstream)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,10 @@
 workspace(name = "tf_serving")
 
+local_repository(
+    name = "org_tensorflow",
+    path = "tensorflow",
+)
+
 # Please add all new TensorFlow Serving dependencies in workspace.bzl.
 load('//tensorflow_serving:workspace.bzl', 'tf_serving_workspace')
-tf_serving_workspace(__workspace_dir__)
+tf_serving_workspace()

--- a/tensorflow_serving/workspace.bzl
+++ b/tensorflow_serving/workspace.bzl
@@ -1,20 +1,15 @@
 # TensorFlow Serving external dependencies that can be loaded in WORKSPACE
 # files.
 
-load('//tensorflow/tensorflow:workspace.bzl', 'tf_workspace')
+load('@org_tensorflow//tensorflow:workspace.bzl', 'tf_workspace')
 
 # All TensorFlow Serving external dependencies.
 # workspace_dir is the absolute path to the TensorFlow Serving repo. If linked
 # as a submodule, it'll likely be '__workspace_dir__ + "/serving"'
-def tf_serving_workspace(workspace_dir):
-  native.local_repository(
-    name = "org_tensorflow",
-    path = workspace_dir + "/tensorflow",
-  )
-
+def tf_serving_workspace():
   native.local_repository(
     name = "inception_model",
-    path = workspace_dir + "/tf_models/inception",
+    path = "tf_models/inception",
   )
 
   tf_workspace("tensorflow/", "@org_tensorflow")


### PR DESCRIPTION
Having issues building `tensorflow` as part of serving, attempting to update the dependency to the `r0.10` branch and include necessary updates.
- Pin Tensorflow to r0.10 release branch (based upon upstream cuda installation fixes)
- Cherry-pick changes to serving in order to take advantage of `r0.10`
