### PR TITLE
Attempt to fix some issues with dockerfile

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -44,7 +44,7 @@ RUN pip install enum34 futures six && \
 #   https://bugs.launchpad.net/trusty-backports/+bug/1368094
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
     apt-get update && \
-    apt-get install -y openjdk-8-jdk openjdk-8-jre-headless && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk openjdk-8-jre-headless && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -30,7 +30,7 @@ RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
 
 # Set up grpc
 
-RUN pip install enum34 futures six && \
+RUN pip install enum34 futures six mock && \
     pip install --pre 'protobuf>=3.0.0a3' && \
     pip install -i https://testpypi.python.org/simple --pre grpcio
 

--- a/tensorflow_serving/tools/docker/Dockerfile.devel
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
         build-essential \
         curl \
         git \
+        libcurl3-dev \
         libfreetype6-dev \
         libpng12-dev \
         libzmq3-dev \
@@ -13,11 +14,12 @@ RUN apt-get update && apt-get install -y \
         python-dev \
         python-numpy \
         python-pip \
+        rsync \
         software-properties-common \
         swig \
+        unzip \
         zip \
         zlib1g-dev \
-        libcurl3-dev \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -29,7 +31,7 @@ RUN curl -fSsL -O https://bootstrap.pypa.io/get-pip.py && \
 # Set up grpc
 
 RUN pip install enum34 futures six && \
-    pip install --pre protobuf>=3.0.0a3 && \
+    pip install --pre 'protobuf>=3.0.0a3' && \
     pip install -i https://testpypi.python.org/simple --pre grpcio
 
 # Set up Bazel.
@@ -56,7 +58,7 @@ RUN echo "build --spawn_strategy=standalone --genrule_strategy=standalone" \
     >>/root/.bazelrc
 ENV BAZELRC /root/.bazelrc
 # Install the most recent bazel release.
-ENV BAZEL_VERSION 0.2.0
+ENV BAZEL_VERSION 0.3.1
 WORKDIR /
 RUN mkdir /bazel && \
     cd /bazel && \


### PR DESCRIPTION
Fixes for the CPU Docker build of tensorflow/serving.
- Integrate upstream changes from the [tensorflow/tensorflow](http://github.com/tensorflow/tensorflow) docker file.
  - Additional packages
  - Bazel 0.3.x
  - Simplify JDK install
- Address syntax issues in pip package installation
- Install missing `mock` package to allow tests to pass.

This is really only necessary to get the image created, once inside of the running container we can use the master (or personal fork) of tensorflow/serving.

cc @yzli
